### PR TITLE
Bump react-styleguidist to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "deepmerge": "^1.5.2",
     "ora": "^1.3.0",
-    "react-styleguidist": "^6.2.0"
+    "react-styleguidist": "^7.2.0"
   }
 }


### PR DESCRIPTION
According to https://github.com/styleguidist/react-styleguidist/releases/tag/v7.0.0 no changes required to this middleware. In my project styleguidist starts and build without problems.